### PR TITLE
README

### DIFF
--- a/ganalytics.php
+++ b/ganalytics.php
@@ -1,0 +1,44 @@
+<?php
+// GAnalytics plugin, https://github.com/datenstrom/yellow-plugins/tree/master/ganalytics
+// Copyright (c) 2013-2017 Datenstrom, https://datenstrom.se
+// This file may be used and distributed under the terms of the public license.
+/*
+Autor: Ami Swami
+Install: Put ganalytics.php in plugin directory
+Configure: Add in the config.ini file the google analytics code, for example: 
+
+gaTrackingId: UA-0000000-0
+*/
+
+class YellowGAnalytics
+{
+	const VERSION = "0.7.1";
+	var $yellow;			//access to API
+	
+	// Handle initialisation
+	function onLoad($yellow)
+	{
+		$this->yellow = $yellow;
+		$this->yellow->config->setDefault("gaTrackingId", "yellow");
+	}
+	
+	// Handle page extra HTML data
+	function onExtra($name)
+	{
+		$output = NULL;
+		if($name=="footer")
+		{
+			$gaId = $this->yellow->config->get("gaTrackingId");
+			if(empty($url)) $url = $this->yellow->toolbox->getServerUrl();
+			$output = "<script>\n";
+			$output .= "(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');\n";
+			$output .= "ga('create', '".strencode($gaId)."', 'auto');\n";
+			$output .= "  ga('send', 'pageview');\n";
+			$output .= "</script>";
+		}
+		return $output;		
+	}
+}
+
+$yellow->plugins->register("ganalytics", "YellowGAnalytics", YellowGAnalytics::VERSION);
+?>


### PR DESCRIPTION
GAnalytics plugin 0.7.2
========================

Google Analytics is an open-source web analytics software.


## How do I install this?

1. If not installed, then [Download and install Datenstrom Yellow](https://github.com/datenstrom/yellow/).
2. [Download plugin](https://github.com/datenstrom/yellow-plugins/raw/master/zip/ganalytics.zip). If you are using Safari, right click and select 'Download file as'.
3. Copy `ganalytics.php` into your `system/plugins` folder.

To uninstall delete the plugin files.

## How to use ganalytics?

To use the plugin open file `system/config/config.ini`, add line gaTrackingId: UA-0000000-0  
You can find your URL and ID in the [Google Analytics administration](https://analytics.google.com/analytics/web/).
 
## Example

Adding ganalytics:

gaTrackingId: UA-0000000-0

## Developer

jweblog  
https://github.com/jweblog/
